### PR TITLE
Use Java8 date classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
         <jersey.version>2.29.1</jersey.version>
 
         <jackson.version>2.10.0</jackson.version>
-        <jodatime.version>2.10.5</jodatime.version>
 
         <jwt.api>${project.basedir}/src/main/resources/swagger/jwt.yaml</jwt.api>
         <cm.api>https://raw.githubusercontent.com/AdobeDocs/cloudmanager-api-docs/master/swagger-specs/api.yaml</cm.api>
@@ -104,7 +103,7 @@
                             <language>java</language>
                             <configOptions>
                                 <serializableModel>true</serializableModel>
-                                <dateLibrary>joda</dateLibrary>
+                                <dateLibrary>java8</dateLibrary>
                             </configOptions>
                             <library>jersey2</library>
                         </configuration>
@@ -126,7 +125,7 @@
                             <language>java</language>
                             <configOptions>
                                 <serializableModel>true</serializableModel>
-                                <dateLibrary>joda</dateLibrary>
+                                <dateLibrary>java8</dateLibrary>
                             </configOptions>
                             <library>jersey2</library>
                         </configuration>
@@ -149,7 +148,7 @@
                             <language>java</language>
                             <configOptions>
                                 <serializableModel>true</serializableModel>
-                                <dateLibrary>joda</dateLibrary>
+                                <dateLibrary>java8</dateLibrary>
                             </configOptions>
                             <library>jersey2</library>
                         </configuration>
@@ -463,17 +462,10 @@
             <artifactId>jackson-module-jaxb-annotations</artifactId>
             <version>${jackson.version}</version>
         </dependency>
-
-        <!-- Joda time: if you use it -->
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-joda</artifactId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>${jodatime.version}</version>
         </dependency>
 
         <!-- Base64 encoding that works in both JVM and Android -->

--- a/src/test/resources/environments/download-logs-success.json
+++ b/src/test/resources/environments/download-logs-success.json
@@ -51,7 +51,7 @@
               },
               "service": "author",
               "name": "aemerror",
-              "date": "2019-09-8",
+              "date": "2019-09-08",
               "programId": "2",
               "environmentId": "1"
             },
@@ -64,7 +64,7 @@
               },
               "service": "author",
               "name": "aemerror",
-              "date": "2019-09-7",
+              "date": "2019-09-07",
               "programId": "2",
               "environmentId": "1"
             }


### PR DESCRIPTION
This closes #26

## Motivation and Context

Reduce number of dependencies

## How Has This Been Tested?

Currently the PR fails, because getEnvironmentLogs (https://github.com/AdobeDocs/cloudmanager-api-docs/blob/f6be183a5669b7f126669b159d736aa7f8c9e4ee/swagger-specs/api.yaml#L1020) returns a non-compliant date `2019-09-8` instead of `2019-09-08` as required by the spec (https://swagger.io/docs/specification/data-models/data-types/#string) for format `date` (https://github.com/AdobeDocs/cloudmanager-api-docs/blob/f6be183a5669b7f126669b159d736aa7f8c9e4ee/swagger-specs/api.yaml#L2101)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
