### PR TITLE
Add serialUID to serializeable classes.

### DIFF
--- a/src/main/java/io/adobe/cloudmanager/model/EmbeddedProgram.java
+++ b/src/main/java/io/adobe/cloudmanager/model/EmbeddedProgram.java
@@ -32,6 +32,7 @@ import lombok.experimental.Delegate;
 @ToString
 @EqualsAndHashCode
 public class EmbeddedProgram extends io.adobe.cloudmanager.swagger.model.EmbeddedProgram {
+  private static final long serialVersionUID = 1L;
 
   public EmbeddedProgram(io.adobe.cloudmanager.swagger.model.EmbeddedProgram delegate, CloudManagerApi client) {
     this.delegate = delegate;

--- a/src/main/java/io/adobe/cloudmanager/model/Environment.java
+++ b/src/main/java/io/adobe/cloudmanager/model/Environment.java
@@ -33,6 +33,7 @@ import lombok.experimental.Delegate;
 @ToString
 @EqualsAndHashCode
 public class Environment extends io.adobe.cloudmanager.swagger.model.Environment {
+  private static final long serialVersionUID = 1L;
 
   @Delegate
   private final io.adobe.cloudmanager.swagger.model.Environment delegate;

--- a/src/main/java/io/adobe/cloudmanager/model/EnvironmentLog.java
+++ b/src/main/java/io/adobe/cloudmanager/model/EnvironmentLog.java
@@ -30,6 +30,8 @@ import lombok.experimental.Delegate;
 @EqualsAndHashCode
 public class EnvironmentLog extends io.adobe.cloudmanager.swagger.model.EnvironmentLog {
 
+  private static final long serialVersionUID = 1L;
+
   public EnvironmentLog(io.adobe.cloudmanager.swagger.model.EnvironmentLog log) {
     this.delegate = log;
   }

--- a/src/main/java/io/adobe/cloudmanager/model/Pipeline.java
+++ b/src/main/java/io/adobe/cloudmanager/model/Pipeline.java
@@ -36,6 +36,8 @@ import lombok.experimental.Delegate;
 @EqualsAndHashCode
 public class Pipeline extends io.adobe.cloudmanager.swagger.model.Pipeline {
 
+  private static final long serialVersionUID = 1L;
+
   @Delegate
   private final io.adobe.cloudmanager.swagger.model.Pipeline delegate;
   @ToString.Exclude

--- a/src/main/java/io/adobe/cloudmanager/model/PipelineExecution.java
+++ b/src/main/java/io/adobe/cloudmanager/model/PipelineExecution.java
@@ -46,6 +46,8 @@ import static io.adobe.cloudmanager.CloudManagerApiException.*;
 @EqualsAndHashCode
 public class PipelineExecution extends io.adobe.cloudmanager.swagger.model.PipelineExecution {
 
+  private static final long serialVersionUID = 1L;
+
   public static final String ACTION_APPROVAL = "approval";
   public static final String ACTION_SCHEDULE = "schedule";
   public static final String ACTION_DEPLOY = "deploy";

--- a/src/main/java/io/adobe/cloudmanager/model/PipelineExecutionStepState.java
+++ b/src/main/java/io/adobe/cloudmanager/model/PipelineExecutionStepState.java
@@ -35,6 +35,8 @@ import lombok.experimental.Delegate;
 @EqualsAndHashCode
 public class PipelineExecutionStepState extends io.adobe.cloudmanager.swagger.model.PipelineExecutionStepState {
 
+  private static final long serialVersionUID = 1L;
+
   @Delegate
   private final io.adobe.cloudmanager.swagger.model.PipelineExecutionStepState delegate;
   @ToString.Exclude

--- a/src/main/java/io/adobe/cloudmanager/model/Variable.java
+++ b/src/main/java/io/adobe/cloudmanager/model/Variable.java
@@ -28,6 +28,8 @@ import lombok.experimental.Delegate;
 @EqualsAndHashCode
 public class Variable extends io.adobe.cloudmanager.swagger.model.Variable {
 
+  private static final long serialVersionUID = 1L;
+
   public Variable() {
     this.delegate = new io.adobe.cloudmanager.swagger.model.Variable();
   }


### PR DESCRIPTION
## Description

Model classes which implement the serializable interface through inheritance don't have a `serialVersionUID`. 

This is needed to correctly serialize the objects.

## Related Issue

Solves #24

## Motivation and Context


## How Has This Been Tested?
No tests needed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
