### PR TITLE
Updated org.apache.commons:commons-text to fix CVE-2022-42889

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -604,7 +604,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.9</version>
+            <version>1.10.0</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
Updated dependency to address vulnerability.

## Description

Updated dependency of org.apache.commons:commons-text to 1.10.0 to address [CVE-2022-42889](https://nvd.nist.gov/vuln/detail/CVE-2022-42889#range-8476706).
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
