### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Store Version
         id: store-version
-        run: echo "version=$(grep ^scm.tag= release.properties | sed -e 's/scm.tag=aio-lib-cloudmanager-//g')" >> $GITHUB_OUTPUT
+        run: echo "version=$(grep ^scm.tag= release.properties | sed -e 's/scm.tag=aio-lib-cloudmanager-//g')" >> "$GITHUB_OUTPUT"
 
   github-release:
     needs: tag

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Store Version
         id: store-version
-        run: echo "::set-output name=version::$(grep ^scm.tag= release.properties | sed -e 's/scm.tag=aio-lib-cloudmanager-//g')"
+        run: echo "version=$(grep ^scm.tag= release.properties | sed -e 's/scm.tag=aio-lib-cloudmanager-//g')" >> $GITHUB_OUTPUT
 
   github-release:
     needs: tag


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter